### PR TITLE
AV-79005: Fixes to Add SameSite Cookie Script

### DIFF
--- a/security/add_samesite_cookie.md
+++ b/security/add_samesite_cookie.md
@@ -41,15 +41,24 @@ when HTTP_RESPONSE {
 headers = avi.http.get_header()
 avi.http.remove_header("Set-Cookie")
 for k, v in pairs(headers) do
-	if (k == "set-cookie") then
-		for key, val in pairs(v) do
-			--only modify if Set-Cookie header does not have SameSite attribute
-			if	string.contains(string.lower(val), "samesite") then
-				avi.http.add_header("Set-Cookie", val)
-			else
-				avi.http.add_header("Set-Cookie", val ..", samesite=None; secure;")
-			end
-		end
-	end
+    if (k == "set-cookie") then
+        if (type(v) == "string") then
+            -- If there's only one SameSite cookie header then v is a string
+            -- v needs to be converted to a table
+            v = {v}
+        end
+
+        for key, val in pairs(v) do
+            -- only modify if Set-Cookie header does not have SameSite attribute
+            new_val = val
+            if not string.contains(string.lower(val), "samesite") then
+                new_val = val .."; samesite=None"
+            end
+            if not string.contains(string.lower(new_val), "secure") then
+                new_val = new_val .."; secure"
+            end
+            avi.http.add_header("Set-Cookie", new_val)
+        end
+    end
 end
 ```


### PR DESCRIPTION
- Add check for the case where there's only one Set-Cookie header from the server response
- Check to see if the Secure attribute was not already present before adding it
- Fix use of comma to append SameSite attribute
- Don't add a trailing semicolon in the Set-Cookie header. This isn't explicitly stated in the RFC, but I think it's best to avoid adding a semicolon at the end.

Also, I've added tests for this script here https://github.com/avinetworks/avi-dev/blob/eng/test/avitest/functional/l7/DataScripts/test_L7VSDataScript_SameSite.py. If there are any changes to this script in the future, please inform someone from the L7 Team so that the tests accurately reflect the DataScript we provide.